### PR TITLE
Decode Idle Single Mode (Independent Training)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
 /__pycache__
 /build
 /dist
+card_data.json
+support_card_data.json
+trained_chara_data.json
+trophy_data.json
+race_replays/
+idle_single_mode/

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,3 @@
 /__pycache__
 /build
 /dist
-card_data.json
-support_card_data.json
-trained_chara_data.json
-trophy_data.json
-race_replays/
-idle_single_mode/

--- a/game_structs.py
+++ b/game_structs.py
@@ -1356,6 +1356,384 @@ class WorkTeamStadiumDataObject(CStructureDataclass):
 
 
 # ---------------------------------------------------------------------------
+# Gallop.SkillTips
+# ---------------------------------------------------------------------------
+
+class SkillTipsFields(CStructureDataclass):
+    group_id: c_int32
+    rarity: c_int32
+    level: c_int32
+
+
+@register_runtime_validatable('Gallop::SkillTips')
+class SkillTipsObject(CStructureDataclass):
+    _il2cpp_obj: RuntimeIl2CppObject
+    fields: SkillTipsFields
+
+
+# ---------------------------------------------------------------------------
+# Gallop.SingleModeSupportCard
+# ---------------------------------------------------------------------------
+
+class SingleModeSupportCardFields(CStructureDataclass):
+    position: c_int32
+    support_card_id: c_int32
+    limit_break_count: c_int32
+    exp: c_int32
+    training_partner_state: c_int32
+    owner_viewer_id: c_int64
+    rental_type: c_int32
+
+
+@register_runtime_validatable('Gallop::SingleModeSupportCard')
+class SingleModeSupportCardObject(CStructureDataclass):
+    _il2cpp_obj: RuntimeIl2CppObject
+    fields: SingleModeSupportCardFields
+
+
+# ---------------------------------------------------------------------------
+# Gallop.GroupOutingInfo
+# ---------------------------------------------------------------------------
+
+class GroupOutingInfoFields(CStructureDataclass):
+    chara_id: c_int32
+    is_outing: c_int32
+    story_step: c_int32
+
+
+@register_runtime_validatable('Gallop::GroupOutingInfo')
+class GroupOutingInfoObject(CStructureDataclass):
+    _il2cpp_obj: RuntimeIl2CppObject
+    fields: GroupOutingInfoFields
+
+
+# ---------------------------------------------------------------------------
+# Gallop.EvaluationInfo
+# ---------------------------------------------------------------------------
+
+class EvaluationInfoFields(CStructureDataclass):
+    target_id: c_int32
+    evaluation: c_int32
+    is_outing: c_int32
+    story_step: c_int32
+    is_appear: c_int32
+    group_outing_info_array: GenericArrayPtr[C_Ptr[GroupOutingInfoObject]]
+
+
+@register_runtime_validatable('Gallop::EvaluationInfo')
+class EvaluationInfoObject(CStructureDataclass):
+    _il2cpp_obj: RuntimeIl2CppObject
+    fields: EvaluationInfoFields
+
+
+# ---------------------------------------------------------------------------
+# Gallop.TrainingLevelInfo
+# ---------------------------------------------------------------------------
+
+class TrainingLevelInfoFields(CStructureDataclass):
+    command_id: c_int32
+    level: c_int32
+
+
+@register_runtime_validatable('Gallop::TrainingLevelInfo')
+class TrainingLevelInfoObject(CStructureDataclass):
+    _il2cpp_obj: RuntimeIl2CppObject
+    fields: TrainingLevelInfoFields
+
+
+# ---------------------------------------------------------------------------
+# Gallop.GuestOutingInfo
+# ---------------------------------------------------------------------------
+
+class GuestOutingInfoFields(CStructureDataclass):
+    support_card_id: c_int32
+    story_step: c_int32
+    group_outing_info_array: GenericArrayPtr[C_Ptr[GroupOutingInfoObject]]
+
+
+@register_runtime_validatable('Gallop::GuestOutingInfo')
+class GuestOutingInfoObject(CStructureDataclass):
+    _il2cpp_obj: RuntimeIl2CppObject
+    fields: GuestOutingInfoFields
+
+
+# ---------------------------------------------------------------------------
+# Gallop.SingleModeSkillUpgrade
+# ---------------------------------------------------------------------------
+
+class SingleModeSkillUpgradeFields(CStructureDataclass):
+	condition_id: c_int32
+	total_count: c_int32
+	current_count: c_int32
+
+
+@register_runtime_validatable('Gallop::SingleModeSkillUpgrade')
+class SingleModeSkillUpgradeObject(CStructureDataclass):
+    _il2cpp_obj: RuntimeIl2CppObject
+    fields: SingleModeSkillUpgradeFields
+
+
+# ---------------------------------------------------------------------------
+# Gallop.SingleModeChara
+# ---------------------------------------------------------------------------
+
+class SingleModeCharaFields(CStructureDataclass):
+    single_mode_chara_id: c_int32
+    card_id: c_int32
+    chara_grade: c_int32
+    speed: c_int32
+    stamina: c_int32
+    power: c_int32
+    wiz: c_int32
+    guts: c_int32
+    vital: c_int32
+    max_speed: c_int32
+    max_stamina: c_int32
+    max_power: c_int32
+    max_wiz: c_int32
+    max_guts: c_int32
+    default_max_speed: c_int32
+    default_max_stamina: c_int32
+    default_max_power: c_int32
+    default_max_wiz: c_int32
+    default_max_guts: c_int32
+    max_vital: c_int32
+    motivation: c_int32
+    fans: c_int32
+    rarity: c_int32
+    race_program_id: c_int32
+    reserve_race_program_id: c_int32
+    race_running_style: c_int32
+    is_short_race: c_int32
+    talent_level: c_int32
+    skill_array: GenericArrayPtr[C_Ptr[SkillDataObject]]
+    disable_skill_id_array: GenericArrayPtr[c_int32]
+    skill_tips_array: GenericArrayPtr[C_Ptr[SkillTipsObject]]
+    support_card_array: GenericArrayPtr[C_Ptr[SingleModeSupportCardObject]]
+    succession_trained_chara_id_1: c_int32
+    succession_trained_chara_id_2: c_int32
+    proper_distance_short: c_int32
+    proper_distance_mile: c_int32
+    proper_distance_middle: c_int32
+    proper_distance_long: c_int32
+    proper_running_style_nige: c_int32
+    proper_running_style_senko: c_int32
+    proper_running_style_sashi: c_int32
+    proper_running_style_oikomi: c_int32
+    proper_ground_turf: c_int32
+    proper_ground_dirt: c_int32
+    turn: c_int32
+    skill_point: c_int32
+    short_cut_state: c_int32
+    state: c_int32
+    playing_state: c_int32
+    scenario_id: c_int32
+    route_id: c_int32
+    start_time: SystemStringObjectPtr
+    evaluation_info_array: GenericArrayPtr[C_Ptr[EvaluationInfoObject]]
+    training_level_info_array: GenericArrayPtr[C_Ptr[TrainingLevelInfoObject]]
+    nickname_id_array: GenericArrayPtr[c_int32]
+    chara_effect_id_array: GenericArrayPtr[c_int32]
+    route_race_id_array: GenericArrayPtr[c_int32]
+    guest_outing_info_array: GenericArrayPtr[C_Ptr[GuestOutingInfoObject]]
+    skill_upgrade_info_array: GenericArrayPtr[C_Ptr[SingleModeSkillUpgradeObject]]
+
+
+@register_runtime_validatable('Gallop::SingleModeChara')
+class SingleModeCharaObject(CStructureDataclass):
+    _il2cpp_obj: RuntimeIl2CppObject
+    fields: SingleModeCharaFields
+
+
+# ---------------------------------------------------------------------------
+# Gallop.ObscuredCharaEffectLog
+# ---------------------------------------------------------------------------
+
+class ObscuredCharaEffectLogFields(CStructureDataclass):
+    charaEffectId: ObscuredInt
+    isActive: ObscuredBool
+
+
+@register_runtime_validatable('Gallop::ObscuredCharaEffectLog')
+class ObscuredCharaEffectLogObject(CStructureDataclass):
+    _il2cpp_obj: RuntimeIl2CppObject
+    fields: ObscuredCharaEffectLogFields
+
+
+# ---------------------------------------------------------------------------
+# Gallop.ObscuredIdleSingleModeSignedInt
+# ---------------------------------------------------------------------------
+
+class ObscuredIdleSingleModeSignedIntFields(CStructureDataclass):
+    sign: ObscuredInt
+    value: ObscuredInt
+
+
+@register_runtime_validatable('Gallop::ObscuredIdleSingleModeSignedInt')
+class ObscuredIdleSingleModeSignedIntObject(CStructureDataclass):
+    _il2cpp_obj: RuntimeIl2CppObject
+    fields: ObscuredIdleSingleModeSignedIntFields
+
+
+# ---------------------------------------------------------------------------
+# Gallop.ObscuredIdleSingleModeGainInfo
+# ---------------------------------------------------------------------------
+
+class ObscuredIdleSingleModeGainInfoFields(CStructureDataclass):
+    speed: C_Ptr[ObscuredIdleSingleModeSignedIntObject]
+    stamina: C_Ptr[ObscuredIdleSingleModeSignedIntObject]
+    power: C_Ptr[ObscuredIdleSingleModeSignedIntObject]
+    wiz: C_Ptr[ObscuredIdleSingleModeSignedIntObject]
+    guts: C_Ptr[ObscuredIdleSingleModeSignedIntObject]
+    maxSpeed: ObscuredInt
+    maxStamina: ObscuredInt
+    maxPower: ObscuredInt
+    maxWiz: ObscuredInt
+    maxGuts: ObscuredInt
+    properDistanceShort: ObscuredInt
+    properDistanceMile: ObscuredInt
+    properDistanceMiddle: ObscuredInt
+    properDistanceLong: ObscuredInt
+    properRunningStyleNige: ObscuredInt
+    properRunningStyleSenko: ObscuredInt
+    properRunningStyleSashi: ObscuredInt
+    properRunningStyleOikomi: ObscuredInt
+    properGroundTurf: ObscuredInt
+    properGroundDirt: ObscuredInt
+    skillPoint: ObscuredInt
+    skillTipsArray: GenericArrayPtr[C_Ptr[SkillTipsObject]]
+
+
+@register_runtime_validatable('Gallop::ObscuredIdleSingleModeGainInfo')
+class ObscuredIdleSingleModeGainInfoObject(CStructureDataclass):
+    _il2cpp_obj: RuntimeIl2CppObject
+    fields: ObscuredIdleSingleModeGainInfoFields
+
+
+# ---------------------------------------------------------------------------
+# Gallop.ObscuredIdleSingleModeSupportCardGainInfo
+# ---------------------------------------------------------------------------
+
+class ObscuredIdleSingleModeSupportCardGainInfoFields(CStructureDataclass):
+    supportCardId: ObscuredInt
+    gainInfo: C_Ptr[ObscuredIdleSingleModeGainInfoObject]
+
+
+@register_runtime_validatable('Gallop::ObscuredIdleSingleModeSupportCardGainInfo')
+class ObscuredIdleSingleModeSupportCardGainInfoObject(CStructureDataclass):
+    _il2cpp_obj: RuntimeIl2CppObject
+    fields: ObscuredIdleSingleModeSupportCardGainInfoFields
+
+
+# ---------------------------------------------------------------------------
+# Gallop.ObscuredFactorInfo
+# ---------------------------------------------------------------------------
+
+class ObscuredFactorInfoFields(CStructureDataclass):
+    factorId: ObscuredInt
+    level: ObscuredInt
+
+
+@register_runtime_validatable('Gallop::ObscuredFactorInfo')
+class ObscuredFactorInfoObject(CStructureDataclass):
+    _il2cpp_obj: RuntimeIl2CppObject
+    fields: ObscuredFactorInfoFields
+
+
+# ---------------------------------------------------------------------------
+# Gallop.ObscuredIdleSingleModeSuccessionFactorGainInfo
+# ---------------------------------------------------------------------------
+
+class ObscuredIdleSingleModeSuccessionFactorGainInfoFields(CStructureDataclass):
+    year: ObscuredInt
+    gainFactorInfoArray: GenericArrayPtr[C_Ptr[ObscuredFactorInfoObject]]
+
+
+@register_runtime_validatable('Gallop::ObscuredIdleSingleModeSuccessionFactorGainInfo')
+class ObscuredIdleSingleModeSuccessionFactorGainInfoObject(CStructureDataclass):
+    _il2cpp_obj: RuntimeIl2CppObject
+    fields: ObscuredIdleSingleModeSuccessionFactorGainInfoFields
+
+
+# ---------------------------------------------------------------------------
+# Gallop.SingleRaceHistory
+# ---------------------------------------------------------------------------
+
+class SingleRaceHistoryFields(CStructureDataclass):
+    turn: c_int32
+    program_id: c_int32
+    weather: c_int32
+    ground_condition: c_int32
+    running_style: c_int32
+    result_rank: c_int32
+    frame_order: c_int32
+    npc_count: c_int32
+
+
+@register_runtime_validatable('Gallop::SingleRaceHistory')
+class SingleRaceHistoryObject(CStructureDataclass):
+    _il2cpp_obj: RuntimeIl2CppObject
+    fields: SingleRaceHistoryFields
+
+
+# ---------------------------------------------------------------------------
+# Gallop.IdleSingleModeRaceHistory
+# ---------------------------------------------------------------------------
+
+class IdleSingleModeRaceHistoryFields(CStructureDataclass):
+    race_history: C_Ptr[SingleRaceHistoryObject]
+    _ignored_1: C_UDeclPtr  # race_reward_info
+    lose_tips_id: ObscuredInt
+
+
+@register_runtime_validatable('Gallop::IdleSingleModeRaceHistory')
+class IdleSingleModeRaceHistoryObject(CStructureDataclass):
+    _il2cpp_obj: RuntimeIl2CppObject
+    fields: IdleSingleModeRaceHistoryFields
+
+
+# ---------------------------------------------------------------------------
+# Gallop.ObscuredIdleSingleModeProgressLogInfo
+# ---------------------------------------------------------------------------
+
+class ObscuredIdleSingleModeProgressLogInfoFields(CStructureDataclass):
+    charaEffectLogArray: GenericArrayPtr[C_Ptr[ObscuredCharaEffectLogObject]]
+    supportCardGainInfoArray: GenericArrayPtr[C_Ptr[ObscuredIdleSingleModeSupportCardGainInfoObject]]
+    eventGainInfo: C_Ptr[ObscuredIdleSingleModeGainInfoObject]
+    successionGainInfo: C_Ptr[ObscuredIdleSingleModeGainInfoObject]
+    successionFactorGainArray: GenericArrayPtr[C_Ptr[ObscuredIdleSingleModeSuccessionFactorGainInfoObject]]
+    raceHistoryArray: GenericArrayPtr[C_Ptr[IdleSingleModeRaceHistoryObject]]
+    gainSkillIdArray: GenericArrayPtr[ObscuredInt]
+    totalSkillPoint: ObscuredInt
+
+
+@register_runtime_validatable('Gallop::ObscuredIdleSingleModeProgressLogInfo')
+class ObscuredIdleSingleModeProgressLogInfoObject(CStructureDataclass):
+    _il2cpp_obj: RuntimeIl2CppObject
+    fields: ObscuredIdleSingleModeProgressLogInfoFields
+
+
+# ---------------------------------------------------------------------------
+# Gallop.WorkIdleSingleMode
+# ---------------------------------------------------------------------------
+
+class WorkIdleSingleModeDataFields(CStructureDataclass):
+    _ignored_1: ObscuredInt  # state
+    charaInfo: C_Ptr[SingleModeCharaObject]
+    startTime: c_int64
+    endTime: c_int64
+    _ignored_2: ObscuredInt  # singleModePlayingState
+    progressLogInfo: C_Ptr[ObscuredIdleSingleModeProgressLogInfoObject]
+    _ignored_3: C_UDeclPtr  # workCharaData is always null
+
+
+@register_runtime_validatable('Gallop::WorkIdleSingleModeData')
+class WorkIdleSingleModeDataObject(CStructureDataclass):
+    _il2cpp_obj: RuntimeIl2CppObject
+    fields: WorkIdleSingleModeDataFields
+
+
+# ---------------------------------------------------------------------------
 # Gallop.WorkDataManager object hierarchy
 # ---------------------------------------------------------------------------
 
@@ -1370,7 +1748,8 @@ class WorkDataManagerFields(CStructureDataclass):
     trophy: C_Ptr[WorkTrophyDataObject]
     _ignored_4: ArrayType[C_UDeclPtr, L[4]]
     teamStadiumData: C_Ptr[WorkTeamStadiumDataObject]
-    _ignored_5: ArrayType[C_UDeclPtr, L[30]]  # directoryData … factorResearchData
+    _ignored_5: ArrayType[C_UDeclPtr, L[31]]  # directoryData … optionData
+    idleSingleModeData: C_Ptr[WorkIdleSingleModeDataObject]
 
 
 @register_runtime_validatable('Gallop::WorkDataManager')

--- a/game_structs.py
+++ b/game_structs.py
@@ -1677,12 +1677,68 @@ class SingleRaceHistoryObject(CStructureDataclass):
 
 
 # ---------------------------------------------------------------------------
+# Gallop.RaceRewardData
+# ---------------------------------------------------------------------------
+
+class RaceRewardDataFields(CStructureDataclass):
+    item_type: C_Int[c_int32]
+    item_id: C_Int[c_int32]
+    item_num: C_Int[c_int32]
+
+
+@register_runtime_validatable('Gallop::RaceRewardData')
+class RaceRewardDataObject(CStructureDataclass):
+    _il2cpp_obj: RuntimeIl2CppObject
+    fields: RaceRewardDataFields
+
+
+# ---------------------------------------------------------------------------
+# Gallop.RaceRewardLimitData
+# ---------------------------------------------------------------------------
+
+class RaceRewardLimitDataFields(CStructureDataclass):
+    reward_id: C_Int[c_int32]
+    item_type: C_Int[c_int32]
+    item_id: C_Int[c_int32]
+    item_num: C_Int[c_int32]
+    rest_count: C_Int[c_int32]
+
+
+@register_runtime_validatable('Gallop::RaceRewardLimitData')
+class RaceRewardLimitDataObject(CStructureDataclass):
+    _il2cpp_obj: RuntimeIl2CppObject
+    fields: RaceRewardLimitDataFields
+
+
+# ---------------------------------------------------------------------------
+# Gallop.CharaRaceReward
+# ---------------------------------------------------------------------------
+
+class CharaRaceRewardFields(CStructureDataclass):
+    result_rank: C_Int[c_int32]
+    result_time: C_Int[c_int32]
+    race_reward: GenericArrayPtr[C_Ptr[RaceRewardDataObject]]
+    race_reward_bonus: GenericArrayPtr[C_Ptr[RaceRewardDataObject]]
+    race_reward_plus_bonus: GenericArrayPtr[C_Ptr[RaceRewardDataObject]]
+    race_reward_bonus_win: GenericArrayPtr[C_Ptr[RaceRewardDataObject]]
+    race_reward_limit: GenericArrayPtr[C_Ptr[RaceRewardLimitDataObject]]
+    gained_fans: C_Int[c_int32]
+    campaign_id_array: GenericArrayPtr[c_int32]
+
+
+@register_runtime_validatable('Gallop::CharaRaceReward')
+class CharaRaceRewardObject(CStructureDataclass):
+    _il2cpp_obj: RuntimeIl2CppObject
+    fields: CharaRaceRewardFields
+
+
+# ---------------------------------------------------------------------------
 # Gallop.IdleSingleModeRaceHistory
 # ---------------------------------------------------------------------------
 
 class IdleSingleModeRaceHistoryFields(CStructureDataclass):
     race_history: C_Ptr[SingleRaceHistoryObject]
-    _ignored_1: C_UDeclPtr  # race_reward_info
+    race_reward_info: C_Ptr[CharaRaceRewardObject]
     lose_tips_id: C_Int[c_int32]
 
 

--- a/game_structs.py
+++ b/game_structs.py
@@ -1360,9 +1360,9 @@ class WorkTeamStadiumDataObject(CStructureDataclass):
 # ---------------------------------------------------------------------------
 
 class SkillTipsFields(CStructureDataclass):
-    group_id: c_int32
-    rarity: c_int32
-    level: c_int32
+    group_id: C_Int[c_int32]
+    rarity: C_Int[c_int32]
+    level: C_Int[c_int32]
 
 
 @register_runtime_validatable('Gallop::SkillTips')
@@ -1376,13 +1376,13 @@ class SkillTipsObject(CStructureDataclass):
 # ---------------------------------------------------------------------------
 
 class SingleModeSupportCardFields(CStructureDataclass):
-    position: c_int32
-    support_card_id: c_int32
-    limit_break_count: c_int32
-    exp: c_int32
-    training_partner_state: c_int32
-    owner_viewer_id: c_int64
-    rental_type: c_int32
+    position: C_Int[c_int32]
+    support_card_id: C_Int[c_int32]
+    limit_break_count: C_Int[c_int32]
+    exp: C_Int[c_int32]
+    training_partner_state: C_Int[c_int32]
+    owner_viewer_id: C_Int[c_int64]
+    rental_type: C_Int[c_int32]
 
 
 @register_runtime_validatable('Gallop::SingleModeSupportCard')
@@ -1396,9 +1396,9 @@ class SingleModeSupportCardObject(CStructureDataclass):
 # ---------------------------------------------------------------------------
 
 class GroupOutingInfoFields(CStructureDataclass):
-    chara_id: c_int32
-    is_outing: c_int32
-    story_step: c_int32
+    chara_id: C_Int[c_int32]
+    is_outing: C_Int[c_int32]
+    story_step: C_Int[c_int32]
 
 
 @register_runtime_validatable('Gallop::GroupOutingInfo')
@@ -1412,11 +1412,11 @@ class GroupOutingInfoObject(CStructureDataclass):
 # ---------------------------------------------------------------------------
 
 class EvaluationInfoFields(CStructureDataclass):
-    target_id: c_int32
-    evaluation: c_int32
-    is_outing: c_int32
-    story_step: c_int32
-    is_appear: c_int32
+    target_id: C_Int[c_int32]
+    evaluation: C_Int[c_int32]
+    is_outing: C_Int[c_int32]
+    story_step: C_Int[c_int32]
+    is_appear: C_Int[c_int32]
     group_outing_info_array: GenericArrayPtr[C_Ptr[GroupOutingInfoObject]]
 
 
@@ -1431,8 +1431,8 @@ class EvaluationInfoObject(CStructureDataclass):
 # ---------------------------------------------------------------------------
 
 class TrainingLevelInfoFields(CStructureDataclass):
-    command_id: c_int32
-    level: c_int32
+    command_id: C_Int[c_int32]
+    level: C_Int[c_int32]
 
 
 @register_runtime_validatable('Gallop::TrainingLevelInfo')
@@ -1446,8 +1446,8 @@ class TrainingLevelInfoObject(CStructureDataclass):
 # ---------------------------------------------------------------------------
 
 class GuestOutingInfoFields(CStructureDataclass):
-    support_card_id: c_int32
-    story_step: c_int32
+    support_card_id: C_Int[c_int32]
+    story_step: C_Int[c_int32]
     group_outing_info_array: GenericArrayPtr[C_Ptr[GroupOutingInfoObject]]
 
 
@@ -1462,9 +1462,9 @@ class GuestOutingInfoObject(CStructureDataclass):
 # ---------------------------------------------------------------------------
 
 class SingleModeSkillUpgradeFields(CStructureDataclass):
-	condition_id: c_int32
-	total_count: c_int32
-	current_count: c_int32
+    condition_id: C_Int[c_int32]
+    total_count: C_Int[c_int32]
+    current_count: C_Int[c_int32]
 
 
 @register_runtime_validatable('Gallop::SingleModeSkillUpgrade')
@@ -1478,57 +1478,57 @@ class SingleModeSkillUpgradeObject(CStructureDataclass):
 # ---------------------------------------------------------------------------
 
 class SingleModeCharaFields(CStructureDataclass):
-    single_mode_chara_id: c_int32
-    card_id: c_int32
-    chara_grade: c_int32
-    speed: c_int32
-    stamina: c_int32
-    power: c_int32
-    wiz: c_int32
-    guts: c_int32
-    vital: c_int32
-    max_speed: c_int32
-    max_stamina: c_int32
-    max_power: c_int32
-    max_wiz: c_int32
-    max_guts: c_int32
-    default_max_speed: c_int32
-    default_max_stamina: c_int32
-    default_max_power: c_int32
-    default_max_wiz: c_int32
-    default_max_guts: c_int32
-    max_vital: c_int32
-    motivation: c_int32
-    fans: c_int32
-    rarity: c_int32
-    race_program_id: c_int32
-    reserve_race_program_id: c_int32
-    race_running_style: c_int32
-    is_short_race: c_int32
-    talent_level: c_int32
+    single_mode_chara_id: C_Int[c_int32]
+    card_id: C_Int[c_int32]
+    chara_grade: C_Int[c_int32]
+    speed: C_Int[c_int32]
+    stamina: C_Int[c_int32]
+    power: C_Int[c_int32]
+    wiz: C_Int[c_int32]
+    guts: C_Int[c_int32]
+    vital: C_Int[c_int32]
+    max_speed: C_Int[c_int32]
+    max_stamina: C_Int[c_int32]
+    max_power: C_Int[c_int32]
+    max_wiz: C_Int[c_int32]
+    max_guts: C_Int[c_int32]
+    default_max_speed: C_Int[c_int32]
+    default_max_stamina: C_Int[c_int32]
+    default_max_power: C_Int[c_int32]
+    default_max_wiz: C_Int[c_int32]
+    default_max_guts: C_Int[c_int32]
+    max_vital: C_Int[c_int32]
+    motivation: C_Int[c_int32]
+    fans: C_Int[c_int32]
+    rarity: C_Int[c_int32]
+    race_program_id: C_Int[c_int32]
+    reserve_race_program_id: C_Int[c_int32]
+    race_running_style: C_Int[c_int32]
+    is_short_race: C_Int[c_int32]
+    talent_level: C_Int[c_int32]
     skill_array: GenericArrayPtr[C_Ptr[SkillDataObject]]
     disable_skill_id_array: GenericArrayPtr[c_int32]
     skill_tips_array: GenericArrayPtr[C_Ptr[SkillTipsObject]]
     support_card_array: GenericArrayPtr[C_Ptr[SingleModeSupportCardObject]]
-    succession_trained_chara_id_1: c_int32
-    succession_trained_chara_id_2: c_int32
-    proper_distance_short: c_int32
-    proper_distance_mile: c_int32
-    proper_distance_middle: c_int32
-    proper_distance_long: c_int32
-    proper_running_style_nige: c_int32
-    proper_running_style_senko: c_int32
-    proper_running_style_sashi: c_int32
-    proper_running_style_oikomi: c_int32
-    proper_ground_turf: c_int32
-    proper_ground_dirt: c_int32
-    turn: c_int32
-    skill_point: c_int32
-    short_cut_state: c_int32
-    state: c_int32
-    playing_state: c_int32
-    scenario_id: c_int32
-    route_id: c_int32
+    succession_trained_chara_id_1: C_Int[c_int32]
+    succession_trained_chara_id_2: C_Int[c_int32]
+    proper_distance_short: C_Int[c_int32]
+    proper_distance_mile: C_Int[c_int32]
+    proper_distance_middle: C_Int[c_int32]
+    proper_distance_long: C_Int[c_int32]
+    proper_running_style_nige: C_Int[c_int32]
+    proper_running_style_senko: C_Int[c_int32]
+    proper_running_style_sashi: C_Int[c_int32]
+    proper_running_style_oikomi: C_Int[c_int32]
+    proper_ground_turf: C_Int[c_int32]
+    proper_ground_dirt: C_Int[c_int32]
+    turn: C_Int[c_int32]
+    skill_point: C_Int[c_int32]
+    short_cut_state: C_Int[c_int32]
+    state: C_Int[c_int32]
+    playing_state: C_Int[c_int32]
+    scenario_id: C_Int[c_int32]
+    route_id: C_Int[c_int32]
     start_time: SystemStringObjectPtr
     evaluation_info_array: GenericArrayPtr[C_Ptr[EvaluationInfoObject]]
     training_level_info_array: GenericArrayPtr[C_Ptr[TrainingLevelInfoObject]]
@@ -1660,14 +1660,14 @@ class ObscuredIdleSingleModeSuccessionFactorGainInfoObject(CStructureDataclass):
 # ---------------------------------------------------------------------------
 
 class SingleRaceHistoryFields(CStructureDataclass):
-    turn: c_int32
-    program_id: c_int32
-    weather: c_int32
-    ground_condition: c_int32
-    running_style: c_int32
-    result_rank: c_int32
-    frame_order: c_int32
-    npc_count: c_int32
+    turn: C_Int[c_int32]
+    program_id: C_Int[c_int32]
+    weather: C_Int[c_int32]
+    ground_condition: C_Int[c_int32]
+    running_style: C_Int[c_int32]
+    result_rank: C_Int[c_int32]
+    frame_order: C_Int[c_int32]
+    npc_count: C_Int[c_int32]
 
 
 @register_runtime_validatable('Gallop::SingleRaceHistory')
@@ -1683,7 +1683,7 @@ class SingleRaceHistoryObject(CStructureDataclass):
 class IdleSingleModeRaceHistoryFields(CStructureDataclass):
     race_history: C_Ptr[SingleRaceHistoryObject]
     _ignored_1: C_UDeclPtr  # race_reward_info
-    lose_tips_id: ObscuredInt
+    lose_tips_id: C_Int[c_int32]
 
 
 @register_runtime_validatable('Gallop::IdleSingleModeRaceHistory')
@@ -1720,8 +1720,8 @@ class ObscuredIdleSingleModeProgressLogInfoObject(CStructureDataclass):
 class WorkIdleSingleModeDataFields(CStructureDataclass):
     _ignored_1: ObscuredInt  # state
     charaInfo: C_Ptr[SingleModeCharaObject]
-    startTime: c_int64
-    endTime: c_int64
+    startTime: C_Int[c_int64]
+    endTime: C_Int[c_int64]
     _ignored_2: ObscuredInt  # singleModePlayingState
     progressLogInfo: C_Ptr[ObscuredIdleSingleModeProgressLogInfoObject]
     _ignored_3: C_UDeclPtr  # workCharaData is always null

--- a/json_encoders.py
+++ b/json_encoders.py
@@ -2,25 +2,25 @@
 from __future__ import annotations
 
 import re
-from ctypes import c_int32
+from ctypes import c_int32, c_int64
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta, timezone
 from typing import Any, Optional, Protocol
 
 from ctypes_utils import C_Ptr
 from game_structs import (AcquiredSkillObject, BgSeason, CardDataDictionaryEntry, CardRarity, CharaGradeType,
-                          CourseDistanceType, DefeatType, FactorDataObject, FactorDataUpgradeHistoryObject,
+                          CourseDistanceType, DefeatType, EvaluationInfoObject, FactorDataObject, FactorDataUpgradeHistoryObject,
                           FactorInfoObject, FavoriteDataDictionaryEntry, FriendDataObject, GenericArrayPtr,
-                          GenericDictionary, GenericList, HintLevelDictionaryEntry, HorseDataObject, InitialLaneType,
-                          MainStoryRaceGimmickType, ProperGrade, RaceCourseSetObject, RaceDifficulty,
+                          GenericDictionary, GenericList, GroupOutingInfoObject, GuestOutingInfoObject, HintLevelDictionaryEntry, HorseDataObject, IdleSingleModeRaceHistoryObject, InitialLaneType,
+                          MainStoryRaceGimmickType, ObscuredCharaEffectLogObject, ObscuredFactorInfoObject, ObscuredIdleSingleModeGainInfoObject, ObscuredIdleSingleModeProgressLogInfoObject, ObscuredIdleSingleModeSignedIntObject, ObscuredIdleSingleModeSuccessionFactorGainInfoObject, ObscuredIdleSingleModeSupportCardGainInfoObject, ProperGrade, RaceCourseSetObject, RaceDifficulty,
                           RaceGroundCondition, RaceHistoryInfoObject, RaceHorseDataObject,
                           RaceHorseDataRaceResultObject, RaceInfoObject, RaceManagerStaticFields, RaceMotivation,
                           RaceParameterObject, RaceRunningType, RaceTime, RaceType, RaceWeather,
-                          ResultBoardConditionType, Rotation, RunningStyleEx, SkillDataObject,
+                          ResultBoardConditionType, Rotation, RunningStyleEx, SingleModeCharaObject, SingleModeSkillUpgradeObject, SingleModeSupportCardObject, SingleRaceHistoryObject, SkillDataObject, SkillTipsObject,
                           SuccessionCharaDataObject, SuccessionCharaPosition, SuccessionHistoryObject,
                           SupportCardDataDictionaryEntry, TeamStadiumRaceCharaResultObject, TeamStadiumRaceResultObject,
                           TeamStadiumResultBonusDataObject, TeamStadiumResultScoreDataObject,
-                          TrainedCharaDataDictionaryEntry, TrainedCharaDataObject, TrainedCharaSupportCardDataObject,
+                          TrainedCharaDataDictionaryEntry, TrainedCharaDataObject, TrainedCharaSupportCardDataObject, TrainingLevelInfoObject,
                           TrophyDataCharaIdListDictionaryEntry, TrophyDataDictionaryEntry, TurfVisionType,
                           WorkDataManagerObject)
 from logger import logger
@@ -1340,3 +1340,291 @@ def decode_race_info_replay(data: RaceInfoReplayExtractionData) -> RaceReplayOut
     winner = next(horse for horse in payload["raceHorse"] if horse["finishOrder"] == 0)
 
     return RaceReplayOutput(key=_race_info_replay_key(payload, winner), payload=payload)
+
+
+# ---------------------------------------------------------------------------
+# Independent training results extraction
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class IdleSingleModeOutput:
+    key: str
+    payload: dict[str, Any]
+
+@dataclass(frozen=True)
+class IdleSingleModeExtractionData:
+    charaInfo: C_Ptr[SingleModeCharaObject]
+    startTime: c_int64
+    endTime: c_int64
+    progressLogInfo: C_Ptr[ObscuredIdleSingleModeProgressLogInfoObject]
+
+    def fingerprint(self) -> ExtractorFingerprint:
+        return (
+            "idle_single_mode",
+            _pointer_fingerprint(self.charaInfo),
+            self.startTime,
+            self.endTime,
+            _pointer_fingerprint(self.progressLogInfo),
+        )
+
+def resolve_idle_single_mode(wdm: WorkDataManagerObject) -> Optional[IdleSingleModeExtractionData]:
+    idlePtr = wdm.fields.idleSingleModeData
+    if not idlePtr:
+        logger.debug("WorkDataManager.idleSingleModeData is null")
+        return None
+
+    c = idlePtr.contents.fields
+    checks = [
+        (c.charaInfo, "charaInfo"),
+        (c.endTime, "endTime"),
+        (c.progressLogInfo, "progressLogInfo"),
+    ]
+    for (f, name) in checks:
+        if not f:
+            logger.debug(f"Idle single mode data is not ready: WorkDataManager.idleSingleModeData.{name} is null or zero")
+            return None
+
+    return IdleSingleModeExtractionData(
+        charaInfo=c.charaInfo,
+        startTime=c.startTime,
+        endTime=c.endTime,
+        progressLogInfo=c.progressLogInfo,
+    )
+
+def _idle_single_mode_key(chara: SingleModeCharaObject) -> str:
+    return f"{_safe_filename_component(chara.fields.start_time.value)}-{chara.fields.card_id}"
+
+def _decode_skill_tip_entry(s: SkillTipsObject) -> dict[str, Any]:
+    f = s.fields
+    return {
+        "group_id": f.group_id,
+        "rarity": f.rarity,
+        "level": f.level,
+    }
+
+def _decode_single_mode_support_card(s: SingleModeSupportCardObject) -> dict[str, Any]:
+    f = s.fields
+    return {
+        "position": f.position,
+        "support_card_id": f.support_card_id,
+        "limit_break_count": f.limit_break_count,
+        "exp": f.exp,
+        "training_partner_state": f.training_partner_state,
+        "owner_viewer_id": f.owner_viewer_id,
+        "rental_type": f.rental_type,
+    }
+
+def _decode_group_outing_info_entry(go: GroupOutingInfoObject) -> dict[str, Any]:
+    f = go.fields
+    return {
+        "chara_id": f.chara_id,
+        "is_outing": f.is_outing,
+        "story_step": f.story_step,
+    }
+
+def _decode_evaluation_info_entry(e: EvaluationInfoObject) -> dict[str, Any]:
+    f = e.fields
+    return {
+        "target_id": f.target_id,
+        "evaluation": f.evaluation,
+        "is_outing": f.is_outing,
+        "story_step": f.story_step,
+        "is_appear": f.is_appear,
+        "group_outing_info_array": [_decode_group_outing_info_entry(go.contents) for go in f.group_outing_info_array],
+    }
+
+def _decode_training_level_info_entry(t: TrainingLevelInfoObject) -> dict[str, Any]:
+    f = t.fields
+    return {
+        "command_id": f.command_id,
+        "level": f.level,
+    }
+
+def _decode_guest_outing_info_entry(o: GuestOutingInfoObject) -> dict[str, Any]:
+    f = o.fields
+    return {
+        "support_card_id": f.support_card_id,
+        "story_step": f.story_step,
+        "GroupOutingInfoList": [_decode_group_outing_info_entry(go.contents) for go in f.group_outing_info_array]
+    }
+
+def _decode_skill_upgrade_info_entry(u: SingleModeSkillUpgradeObject) -> dict[str, Any]:
+    f = u.fields
+    return {
+        "condition_id": f.condition_id,
+        "total_count": f.total_count,
+        "current_count": f.current_count,
+    }
+
+def _decode_single_mode_chara(chara: SingleModeCharaObject) -> dict[str, Any]:
+    f = chara.fields
+    return {
+        "single_mode_chara_id": f.single_mode_chara_id,
+        "card_id": f.card_id,
+        "chara_grade": f.chara_grade,
+        "speed": f.speed,
+        "stamina": f.stamina,
+        "power": f.power,
+        "wiz": f.wiz,
+        "guts": f.guts,
+        "vital": f.vital,
+        "max_speed": f.max_speed,
+        "max_stamina": f.max_stamina,
+        "max_power": f.max_power,
+        "max_wiz": f.max_wiz,
+        "max_guts": f.max_guts,
+        "default_max_speed": f.default_max_speed,
+        "default_max_stamina": f.default_max_stamina,
+        "default_max_power": f.default_max_power,
+        "default_max_wiz": f.default_max_wiz,
+        "default_max_guts": f.default_max_guts,
+        "max_vital": f.max_vital,
+        "motivation": f.motivation,
+        "fans": f.fans,
+        "rarity": f.rarity,
+        "race_program_id": f.race_program_id,
+        "reserve_race_program_id": f.reserve_race_program_id,
+        "race_running_style": f.race_running_style,
+        "is_short_race": f.is_short_race,
+        "talent_level": f.talent_level,
+        "skill_array": [_decode_skill_data_entry(s.contents) for s in f.skill_array],
+        "disable_skill_id_array": list(f.disable_skill_id_array),
+        "skill_tips_array": [_decode_skill_tip_entry(s.contents) for s in f.skill_tips_array],
+        "support_card_array": [_decode_single_mode_support_card(s.contents) for s in f.support_card_array],
+        "succession_trained_chara_id_1": f.succession_trained_chara_id_1,
+        "succession_trained_chara_id_2": f.succession_trained_chara_id_2,
+        "proper_distance_short": f.proper_distance_short,
+        "proper_distance_mile": f.proper_distance_mile,
+        "proper_distance_middle": f.proper_distance_middle,
+        "proper_distance_long": f.proper_distance_long,
+        "proper_running_style_nige": f.proper_running_style_nige,
+        "proper_running_style_senko": f.proper_running_style_senko,
+        "proper_running_style_sashi": f.proper_running_style_sashi,
+        "proper_running_style_oikomi": f.proper_running_style_oikomi,
+        "proper_ground_turf": f.proper_ground_turf,
+        "proper_ground_dirt": f.proper_ground_dirt,
+        "turn": f.turn,
+        "skill_point": f.skill_point,
+        "short_cut_state": f.short_cut_state,
+        "state": f.state,
+        "playing_state": f.playing_state,
+        "scenario_id": f.scenario_id,
+        "route_id": f.route_id,
+        "start_time": f.start_time.value,
+        "evaluation_info_array": [_decode_evaluation_info_entry(e.contents) for e in f.evaluation_info_array],
+        "training_level_info_array": [_decode_training_level_info_entry(t.contents) for t in f.training_level_info_array],
+        "nickname_id_array": list(f.nickname_id_array),
+        "chara_effect_id_array": list(f.chara_effect_id_array),
+        "route_race_id_array": [x.value for x in f.route_race_id_array],
+        "guest_outing_info_array": [_decode_guest_outing_info_entry(o.contents) for o in f.guest_outing_info_array],
+        "skill_upgrade_info_array": [_decode_skill_upgrade_info_entry(u.contents) for u in f.skill_upgrade_info_array],
+    }
+
+def _decode_obscured_chara_effect_log_entry(e: ObscuredCharaEffectLogObject) -> dict[str, Any]:
+    f = e.fields
+    return {
+        "charaEffectId": f.charaEffectId.value,
+        "isActive": f.isActive.value,
+    }
+
+def _decode_idle_single_mode_signed_int(v: ObscuredIdleSingleModeSignedIntObject) -> dict[str, Any]:
+    f = v.fields
+    return {
+        "sign": f.sign.value,
+        "value": f.value.value,
+    }
+
+def _decode_idle_single_mode_gain_info_entry(g: ObscuredIdleSingleModeGainInfoObject) -> dict[str, Any]:
+    f = g.fields
+    return {
+        "speed": _decode_idle_single_mode_signed_int(f.speed.contents),
+        "stamina": _decode_idle_single_mode_signed_int(f.stamina.contents),
+        "power": _decode_idle_single_mode_signed_int(f.power.contents),
+        "wiz": _decode_idle_single_mode_signed_int(f.wiz.contents),
+        "guts": _decode_idle_single_mode_signed_int(f.guts.contents),
+        "maxSpeed": f.maxSpeed.value,
+        "maxStamina": f.maxStamina.value,
+        "maxPower": f.maxPower.value,
+        "maxWiz": f.maxWiz.value,
+        "maxGuts": f.maxGuts.value,
+        "properDistanceShort": f.properDistanceShort.value,
+        "properDistanceMile": f.properDistanceMile.value,
+        "properDistanceMiddle": f.properDistanceMiddle.value,
+        "properDistanceLong": f.properDistanceLong.value,
+        "properRunningStyleNige": f.properRunningStyleNige.value,
+        "properRunningStyleSenko": f.properRunningStyleSenko.value,
+        "properRunningStyleSashi": f.properRunningStyleSashi.value,
+        "properRunningStyleOikomi": f.properRunningStyleOikomi.value,
+        "properGroundTurf": f.properGroundTurf.value,
+        "properGroundDirt": f.properGroundDirt.value,
+        "skillPoint": f.skillPoint.value,
+        "skillTips": [_decode_skill_tip_entry(s.contents) for s in f.skillTipsArray],
+    }
+
+def _decode_idle_single_mode_support_card_gain_info_entry(g: ObscuredIdleSingleModeSupportCardGainInfoObject) -> dict[str, Any]:
+    f = g.fields
+    return {
+        "supportCardId": f.supportCardId.value,
+        "gainInfo": _decode_idle_single_mode_gain_info_entry(f.gainInfo.contents),
+    }
+
+def _decode_obscured_factor_info_entry(i: ObscuredFactorInfoObject) -> dict[str, Any]:
+    f = i.fields
+    return {
+        "factorId": f.factorId.value,
+        "level": f.level.value,
+    }
+
+def _decode_idle_single_mode_succession_factor_gain(sf: ObscuredIdleSingleModeSuccessionFactorGainInfoObject) -> dict[str, Any]:
+    f = sf.fields
+    return {
+        "year": f.year.value,
+        "gainFactorInfoArray": [_decode_obscured_factor_info_entry(i.contents) for i in f.gainFactorInfoArray],
+    }
+
+def _decode_single_race_history_entry(h: SingleRaceHistoryObject) -> dict[str, Any]:
+    f = h.fields
+    return {
+        "turn": f.turn,
+        "program_id": f.program_id,
+        "weather": f.weather,
+        "ground_condition": f.ground_condition,
+        "running_style": f.running_style,
+        "result_rank": f.result_rank,
+        "frame_order": f.frame_order,
+        "npc_count": f.npc_count,
+    }
+
+def _decode_idle_single_mode_race_history_entry(r: IdleSingleModeRaceHistoryObject) -> dict[str, Any]:
+    f = r.fields
+    return {
+        "race_history": _decode_single_race_history_entry(f.race_history.contents),
+        "lose_tips_id": f.lose_tips_id.value,
+    }
+
+def _decode_obscured_idle_single_mode_progress_log_info(progress: ObscuredIdleSingleModeProgressLogInfoObject) -> dict[str, Any]:
+    f = progress.fields
+    return {
+        "charaEffectLog": [_decode_obscured_chara_effect_log_entry(e.contents) for e in f.charaEffectLogArray],
+        "supportCardGainInfo": [_decode_idle_single_mode_support_card_gain_info_entry(g.contents) for g in f.supportCardGainInfoArray],
+        "eventGainInfo": _decode_idle_single_mode_gain_info_entry(f.eventGainInfo.contents),
+        "successionGainInfo": _decode_idle_single_mode_gain_info_entry(f.successionGainInfo.contents),
+        "successionFactorGainArray": [_decode_idle_single_mode_succession_factor_gain(sf.contents) for sf in f.successionFactorGainArray],
+        "raceHistoryArray": [_decode_idle_single_mode_race_history_entry(r.contents) for r in f.raceHistoryArray],
+        "gainSkillIdArray": [id.value for id in f.gainSkillIdArray],
+        "totalSkillPoint": f.totalSkillPoint.value,
+    }
+
+def _decode_idle_single_mode_data(data: IdleSingleModeExtractionData) -> dict[str, Any]:
+    return {
+        "charaInfo": _decode_single_mode_chara(data.charaInfo.contents),
+        "startTime": data.startTime,
+        "endTime": data.endTime,
+        "progressLogInfo": _decode_obscured_idle_single_mode_progress_log_info(data.progressLogInfo.contents),
+    }
+
+def decode_idle_single_mode(data: IdleSingleModeExtractionData) -> IdleSingleModeOutput:
+    return IdleSingleModeOutput(
+        key=_idle_single_mode_key(data.charaInfo.contents),
+        payload=_decode_idle_single_mode_data(data)
+    )

--- a/json_encoders.py
+++ b/json_encoders.py
@@ -8,7 +8,7 @@ from datetime import UTC, datetime, timedelta, timezone
 from typing import Any, Optional, Protocol
 
 from ctypes_utils import C_Int, C_Ptr
-from game_structs import (AcquiredSkillObject, BgSeason, CardDataDictionaryEntry, CardRarity, CharaGradeType,
+from game_structs import (AcquiredSkillObject, BgSeason, CardDataDictionaryEntry, CardRarity, CharaGradeType, CharaRaceRewardObject,
                           CourseDistanceType, DefeatType, EvaluationInfoObject, FactorDataObject,
                           FactorDataUpgradeHistoryObject, FactorInfoObject, FavoriteDataDictionaryEntry,
                           FriendDataObject, GenericArrayPtr, GenericDictionary, GenericList, GroupOutingInfoObject,
@@ -20,7 +20,7 @@ from game_structs import (AcquiredSkillObject, BgSeason, CardDataDictionaryEntry
                           ObscuredIdleSingleModeSupportCardGainInfoObject, ProperGrade, RaceCourseSetObject,
                           RaceDifficulty, RaceGroundCondition, RaceHistoryInfoObject, RaceHorseDataObject,
                           RaceHorseDataRaceResultObject, RaceInfoObject, RaceManagerStaticFields, RaceMotivation,
-                          RaceParameterObject, RaceRunningType, RaceTime, RaceType, RaceWeather,
+                          RaceParameterObject, RaceRewardDataObject, RaceRewardLimitDataObject, RaceRunningType, RaceTime, RaceType, RaceWeather,
                           ResultBoardConditionType, Rotation, RunningStyleEx, SingleModeCharaObject,
                           SingleModeSkillUpgradeObject, SingleModeSupportCardObject, SingleRaceHistoryObject,
                           SkillDataObject, SkillTipsObject, SuccessionCharaDataObject, SuccessionCharaPosition,
@@ -1627,10 +1627,46 @@ def _decode_single_race_history_entry(h: SingleRaceHistoryObject) -> dict[str, A
     }
 
 
+def _decode_race_reward_data_entry(rd: RaceRewardDataObject) -> dict[str, Any]:
+    f = rd.fields
+    return {
+        "item_type": f.item_type,
+        "item_id": f.item_id,
+        "item_num": f.item_num,
+    }
+
+
+def _decode_race_reward_limit_data_entry(ld: RaceRewardLimitDataObject) -> dict[str, Any]:
+    f = ld.fields
+    return {
+        "reward_id": f.reward_id,
+        "item_type": f.item_type,
+        "item_id": f.item_id,
+        "item_num": f.item_num,
+        "rest_count": f.rest_count,
+    }
+
+
+def _decode_chara_race_reward(rr: CharaRaceRewardObject) -> dict[str, Any]:
+    f = rr.fields
+    return {
+        "result_rank": f.result_rank,
+        "result_time": f.result_time,
+        "race_reward": [_decode_race_reward_data_entry(rd.contents) for rd in f.race_reward],
+        "race_reward_bonus": [_decode_race_reward_data_entry(rd.contents) for rd in f.race_reward_bonus],
+        "race_reward_plus_bonus": [_decode_race_reward_data_entry(rd.contents) for rd in f.race_reward_plus_bonus],
+        "race_reward_bonus_win": [_decode_race_reward_data_entry(rd.contents) for rd in f.race_reward_bonus_win],
+        "race_reward_limit": None if not f.race_reward_limit.inner_ptr else [_decode_race_reward_limit_data_entry(ld.contents) for ld in f.race_reward_limit],
+        "gained_fans": f.gained_fans,
+        "campaign_id_array": [x.value for x in f.campaign_id_array],
+    }
+
+
 def _decode_idle_single_mode_race_history_entry(r: IdleSingleModeRaceHistoryObject) -> dict[str, Any]:
     f = r.fields
     return {
         "race_history": _decode_single_race_history_entry(f.race_history.contents),
+        "race_reward_info": _decode_chara_race_reward(f.race_reward_info.contents),
         "lose_tips_id": f.lose_tips_id,
     }
 

--- a/json_encoders.py
+++ b/json_encoders.py
@@ -2,12 +2,12 @@
 from __future__ import annotations
 
 import re
-from ctypes import c_int32
+from ctypes import c_int32, c_int64
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta, timezone
 from typing import Any, Optional, Protocol
 
-from ctypes_utils import C_Ptr
+from ctypes_utils import C_Int, C_Ptr
 from game_structs import (AcquiredSkillObject, BgSeason, CardDataDictionaryEntry, CardRarity, CharaGradeType,
                           CourseDistanceType, DefeatType, EvaluationInfoObject, FactorDataObject,
                           FactorDataUpgradeHistoryObject, FactorInfoObject, FavoriteDataDictionaryEntry,
@@ -1362,8 +1362,8 @@ class IdleSingleModeOutput:
 @dataclass(frozen=True)
 class IdleSingleModeExtractionData:
     charaInfo: C_Ptr[SingleModeCharaObject]
-    startTime: int
-    endTime: int
+    startTime: C_Int[c_int64]
+    endTime: C_Int[c_int64]
     progressLogInfo: C_Ptr[ObscuredIdleSingleModeProgressLogInfoObject]
 
     def fingerprint(self) -> ExtractorFingerprint:
@@ -1402,8 +1402,8 @@ def resolve_idle_single_mode(wdm: WorkDataManagerObject) -> Optional[IdleSingleM
     )
 
 
-def _idle_single_mode_key(chara: SingleModeCharaObject) -> str:
-    return f"{_safe_filename_component(chara.fields.start_time.value)}-{chara.fields.card_id}"
+def _idle_single_mode_key(chara: SingleModeCharaObject, start_time: Any) -> str:
+    return f"{start_time}-{chara.fields.card_id}"
 
 
 def _decode_skill_tip_entry(s: SkillTipsObject) -> dict[str, Any]:
@@ -1661,6 +1661,6 @@ def _decode_idle_single_mode_data(data: IdleSingleModeExtractionData) -> dict[st
 
 def decode_idle_single_mode(data: IdleSingleModeExtractionData) -> IdleSingleModeOutput:
     return IdleSingleModeOutput(
-            key=_idle_single_mode_key(data.charaInfo.contents),
+            key=_idle_single_mode_key(data.charaInfo.contents, data.startTime),
             payload=_decode_idle_single_mode_data(data)
     )

--- a/json_encoders.py
+++ b/json_encoders.py
@@ -2,25 +2,32 @@
 from __future__ import annotations
 
 import re
-from ctypes import c_int32, c_int64
+from ctypes import c_int32
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta, timezone
 from typing import Any, Optional, Protocol
 
 from ctypes_utils import C_Ptr
 from game_structs import (AcquiredSkillObject, BgSeason, CardDataDictionaryEntry, CardRarity, CharaGradeType,
-                          CourseDistanceType, DefeatType, EvaluationInfoObject, FactorDataObject, FactorDataUpgradeHistoryObject,
-                          FactorInfoObject, FavoriteDataDictionaryEntry, FriendDataObject, GenericArrayPtr,
-                          GenericDictionary, GenericList, GroupOutingInfoObject, GuestOutingInfoObject, HintLevelDictionaryEntry, HorseDataObject, IdleSingleModeRaceHistoryObject, InitialLaneType,
-                          MainStoryRaceGimmickType, ObscuredCharaEffectLogObject, ObscuredFactorInfoObject, ObscuredIdleSingleModeGainInfoObject, ObscuredIdleSingleModeProgressLogInfoObject, ObscuredIdleSingleModeSignedIntObject, ObscuredIdleSingleModeSuccessionFactorGainInfoObject, ObscuredIdleSingleModeSupportCardGainInfoObject, ProperGrade, RaceCourseSetObject, RaceDifficulty,
-                          RaceGroundCondition, RaceHistoryInfoObject, RaceHorseDataObject,
+                          CourseDistanceType, DefeatType, EvaluationInfoObject, FactorDataObject,
+                          FactorDataUpgradeHistoryObject, FactorInfoObject, FavoriteDataDictionaryEntry,
+                          FriendDataObject, GenericArrayPtr, GenericDictionary, GenericList, GroupOutingInfoObject,
+                          GuestOutingInfoObject, HintLevelDictionaryEntry, HorseDataObject,
+                          IdleSingleModeRaceHistoryObject, InitialLaneType, MainStoryRaceGimmickType,
+                          ObscuredCharaEffectLogObject, ObscuredFactorInfoObject, ObscuredIdleSingleModeGainInfoObject,
+                          ObscuredIdleSingleModeProgressLogInfoObject, ObscuredIdleSingleModeSignedIntObject,
+                          ObscuredIdleSingleModeSuccessionFactorGainInfoObject,
+                          ObscuredIdleSingleModeSupportCardGainInfoObject, ProperGrade, RaceCourseSetObject,
+                          RaceDifficulty, RaceGroundCondition, RaceHistoryInfoObject, RaceHorseDataObject,
                           RaceHorseDataRaceResultObject, RaceInfoObject, RaceManagerStaticFields, RaceMotivation,
                           RaceParameterObject, RaceRunningType, RaceTime, RaceType, RaceWeather,
-                          ResultBoardConditionType, Rotation, RunningStyleEx, SingleModeCharaObject, SingleModeSkillUpgradeObject, SingleModeSupportCardObject, SingleRaceHistoryObject, SkillDataObject, SkillTipsObject,
-                          SuccessionCharaDataObject, SuccessionCharaPosition, SuccessionHistoryObject,
-                          SupportCardDataDictionaryEntry, TeamStadiumRaceCharaResultObject, TeamStadiumRaceResultObject,
-                          TeamStadiumResultBonusDataObject, TeamStadiumResultScoreDataObject,
-                          TrainedCharaDataDictionaryEntry, TrainedCharaDataObject, TrainedCharaSupportCardDataObject, TrainingLevelInfoObject,
+                          ResultBoardConditionType, Rotation, RunningStyleEx, SingleModeCharaObject,
+                          SingleModeSkillUpgradeObject, SingleModeSupportCardObject, SingleRaceHistoryObject,
+                          SkillDataObject, SkillTipsObject, SuccessionCharaDataObject, SuccessionCharaPosition,
+                          SuccessionHistoryObject, SupportCardDataDictionaryEntry, TeamStadiumRaceCharaResultObject,
+                          TeamStadiumRaceResultObject, TeamStadiumResultBonusDataObject,
+                          TeamStadiumResultScoreDataObject, TrainedCharaDataDictionaryEntry, TrainedCharaDataObject,
+                          TrainedCharaSupportCardDataObject, TrainingLevelInfoObject,
                           TrophyDataCharaIdListDictionaryEntry, TrophyDataDictionaryEntry, TurfVisionType,
                           WorkDataManagerObject)
 from logger import logger
@@ -1351,11 +1358,12 @@ class IdleSingleModeOutput:
     key: str
     payload: dict[str, Any]
 
+
 @dataclass(frozen=True)
 class IdleSingleModeExtractionData:
     charaInfo: C_Ptr[SingleModeCharaObject]
-    startTime: c_int64
-    endTime: c_int64
+    startTime: int
+    endTime: int
     progressLogInfo: C_Ptr[ObscuredIdleSingleModeProgressLogInfoObject]
 
     def fingerprint(self) -> ExtractorFingerprint:
@@ -1367,13 +1375,14 @@ class IdleSingleModeExtractionData:
             _pointer_fingerprint(self.progressLogInfo),
         )
 
+
 def resolve_idle_single_mode(wdm: WorkDataManagerObject) -> Optional[IdleSingleModeExtractionData]:
-    idlePtr = wdm.fields.idleSingleModeData
-    if not idlePtr:
+    idle_ptr = wdm.fields.idleSingleModeData
+    if not idle_ptr:
         logger.debug("WorkDataManager.idleSingleModeData is null")
         return None
 
-    c = idlePtr.contents.fields
+    c = idle_ptr.contents.fields
     checks = [
         (c.charaInfo, "charaInfo"),
         (c.endTime, "endTime"),
@@ -1381,18 +1390,21 @@ def resolve_idle_single_mode(wdm: WorkDataManagerObject) -> Optional[IdleSingleM
     ]
     for (f, name) in checks:
         if not f:
-            logger.debug(f"Idle single mode data is not ready: WorkDataManager.idleSingleModeData.{name} is null or zero")
+            logger.debug(
+                    f"Idle single mode data is not ready: WorkDataManager.idleSingleModeData.{name} is null or zero")
             return None
 
     return IdleSingleModeExtractionData(
-        charaInfo=c.charaInfo,
-        startTime=c.startTime,
-        endTime=c.endTime,
-        progressLogInfo=c.progressLogInfo,
+            charaInfo=c.charaInfo,
+            startTime=c.startTime,
+            endTime=c.endTime,
+            progressLogInfo=c.progressLogInfo,
     )
+
 
 def _idle_single_mode_key(chara: SingleModeCharaObject) -> str:
     return f"{_safe_filename_component(chara.fields.start_time.value)}-{chara.fields.card_id}"
+
 
 def _decode_skill_tip_entry(s: SkillTipsObject) -> dict[str, Any]:
     f = s.fields
@@ -1401,6 +1413,7 @@ def _decode_skill_tip_entry(s: SkillTipsObject) -> dict[str, Any]:
         "rarity": f.rarity,
         "level": f.level,
     }
+
 
 def _decode_single_mode_support_card(s: SingleModeSupportCardObject) -> dict[str, Any]:
     f = s.fields
@@ -1414,6 +1427,7 @@ def _decode_single_mode_support_card(s: SingleModeSupportCardObject) -> dict[str
         "rental_type": f.rental_type,
     }
 
+
 def _decode_group_outing_info_entry(go: GroupOutingInfoObject) -> dict[str, Any]:
     f = go.fields
     return {
@@ -1421,6 +1435,7 @@ def _decode_group_outing_info_entry(go: GroupOutingInfoObject) -> dict[str, Any]
         "is_outing": f.is_outing,
         "story_step": f.story_step,
     }
+
 
 def _decode_evaluation_info_entry(e: EvaluationInfoObject) -> dict[str, Any]:
     f = e.fields
@@ -1433,12 +1448,14 @@ def _decode_evaluation_info_entry(e: EvaluationInfoObject) -> dict[str, Any]:
         "group_outing_info_array": [_decode_group_outing_info_entry(go.contents) for go in f.group_outing_info_array],
     }
 
+
 def _decode_training_level_info_entry(t: TrainingLevelInfoObject) -> dict[str, Any]:
     f = t.fields
     return {
         "command_id": f.command_id,
         "level": f.level,
     }
+
 
 def _decode_guest_outing_info_entry(o: GuestOutingInfoObject) -> dict[str, Any]:
     f = o.fields
@@ -1448,6 +1465,7 @@ def _decode_guest_outing_info_entry(o: GuestOutingInfoObject) -> dict[str, Any]:
         "GroupOutingInfoList": [_decode_group_outing_info_entry(go.contents) for go in f.group_outing_info_array]
     }
 
+
 def _decode_skill_upgrade_info_entry(u: SingleModeSkillUpgradeObject) -> dict[str, Any]:
     f = u.fields
     return {
@@ -1455,6 +1473,7 @@ def _decode_skill_upgrade_info_entry(u: SingleModeSkillUpgradeObject) -> dict[st
         "total_count": f.total_count,
         "current_count": f.current_count,
     }
+
 
 def _decode_single_mode_chara(chara: SingleModeCharaObject) -> dict[str, Any]:
     f = chara.fields
@@ -1512,13 +1531,15 @@ def _decode_single_mode_chara(chara: SingleModeCharaObject) -> dict[str, Any]:
         "route_id": f.route_id,
         "start_time": f.start_time.value,
         "evaluation_info_array": [_decode_evaluation_info_entry(e.contents) for e in f.evaluation_info_array],
-        "training_level_info_array": [_decode_training_level_info_entry(t.contents) for t in f.training_level_info_array],
+        "training_level_info_array": [
+            _decode_training_level_info_entry(t.contents) for t in f.training_level_info_array],
         "nickname_id_array": list(f.nickname_id_array),
         "chara_effect_id_array": list(f.chara_effect_id_array),
         "route_race_id_array": [x.value for x in f.route_race_id_array],
         "guest_outing_info_array": [_decode_guest_outing_info_entry(o.contents) for o in f.guest_outing_info_array],
         "skill_upgrade_info_array": [_decode_skill_upgrade_info_entry(u.contents) for u in f.skill_upgrade_info_array],
     }
+
 
 def _decode_obscured_chara_effect_log_entry(e: ObscuredCharaEffectLogObject) -> dict[str, Any]:
     f = e.fields
@@ -1527,12 +1548,14 @@ def _decode_obscured_chara_effect_log_entry(e: ObscuredCharaEffectLogObject) -> 
         "isActive": f.isActive.value,
     }
 
+
 def _decode_idle_single_mode_signed_int(v: ObscuredIdleSingleModeSignedIntObject) -> dict[str, Any]:
     f = v.fields
     return {
         "sign": f.sign.value,
         "value": f.value.value,
     }
+
 
 def _decode_idle_single_mode_gain_info_entry(g: ObscuredIdleSingleModeGainInfoObject) -> dict[str, Any]:
     f = g.fields
@@ -1561,12 +1584,15 @@ def _decode_idle_single_mode_gain_info_entry(g: ObscuredIdleSingleModeGainInfoOb
         "skillTips": [_decode_skill_tip_entry(s.contents) for s in f.skillTipsArray],
     }
 
-def _decode_idle_single_mode_support_card_gain_info_entry(g: ObscuredIdleSingleModeSupportCardGainInfoObject) -> dict[str, Any]:
+
+def _decode_idle_single_mode_support_card_gain_info_entry(g: ObscuredIdleSingleModeSupportCardGainInfoObject) \
+        -> dict[str, Any]:
     f = g.fields
     return {
         "supportCardId": f.supportCardId.value,
         "gainInfo": _decode_idle_single_mode_gain_info_entry(f.gainInfo.contents),
     }
+
 
 def _decode_obscured_factor_info_entry(i: ObscuredFactorInfoObject) -> dict[str, Any]:
     f = i.fields
@@ -1575,12 +1601,15 @@ def _decode_obscured_factor_info_entry(i: ObscuredFactorInfoObject) -> dict[str,
         "level": f.level.value,
     }
 
-def _decode_idle_single_mode_succession_factor_gain(sf: ObscuredIdleSingleModeSuccessionFactorGainInfoObject) -> dict[str, Any]:
+
+def _decode_idle_single_mode_succession_factor_gain(sf: ObscuredIdleSingleModeSuccessionFactorGainInfoObject) \
+        -> dict[str, Any]:
     f = sf.fields
     return {
         "year": f.year.value,
         "gainFactorInfoArray": [_decode_obscured_factor_info_entry(i.contents) for i in f.gainFactorInfoArray],
     }
+
 
 def _decode_single_race_history_entry(h: SingleRaceHistoryObject) -> dict[str, Any]:
     f = h.fields
@@ -1595,25 +1624,31 @@ def _decode_single_race_history_entry(h: SingleRaceHistoryObject) -> dict[str, A
         "npc_count": f.npc_count,
     }
 
+
 def _decode_idle_single_mode_race_history_entry(r: IdleSingleModeRaceHistoryObject) -> dict[str, Any]:
     f = r.fields
     return {
         "race_history": _decode_single_race_history_entry(f.race_history.contents),
-        "lose_tips_id": f.lose_tips_id.value,
+        "lose_tips_id": f.lose_tips_id,
     }
 
-def _decode_obscured_idle_single_mode_progress_log_info(progress: ObscuredIdleSingleModeProgressLogInfoObject) -> dict[str, Any]:
+
+def _decode_obscured_idle_single_mode_progress_log_info(progress: ObscuredIdleSingleModeProgressLogInfoObject) \
+        -> dict[str, Any]:
     f = progress.fields
     return {
         "charaEffectLog": [_decode_obscured_chara_effect_log_entry(e.contents) for e in f.charaEffectLogArray],
-        "supportCardGainInfo": [_decode_idle_single_mode_support_card_gain_info_entry(g.contents) for g in f.supportCardGainInfoArray],
+        "supportCardGainInfo": [
+            _decode_idle_single_mode_support_card_gain_info_entry(g.contents) for g in f.supportCardGainInfoArray],
         "eventGainInfo": _decode_idle_single_mode_gain_info_entry(f.eventGainInfo.contents),
         "successionGainInfo": _decode_idle_single_mode_gain_info_entry(f.successionGainInfo.contents),
-        "successionFactorGainArray": [_decode_idle_single_mode_succession_factor_gain(sf.contents) for sf in f.successionFactorGainArray],
+        "successionFactorGainArray": [
+            _decode_idle_single_mode_succession_factor_gain(sf.contents) for sf in f.successionFactorGainArray],
         "raceHistoryArray": [_decode_idle_single_mode_race_history_entry(r.contents) for r in f.raceHistoryArray],
         "gainSkillIdArray": [id.value for id in f.gainSkillIdArray],
         "totalSkillPoint": f.totalSkillPoint.value,
     }
+
 
 def _decode_idle_single_mode_data(data: IdleSingleModeExtractionData) -> dict[str, Any]:
     return {
@@ -1623,8 +1658,9 @@ def _decode_idle_single_mode_data(data: IdleSingleModeExtractionData) -> dict[st
         "progressLogInfo": _decode_obscured_idle_single_mode_progress_log_info(data.progressLogInfo.contents),
     }
 
+
 def decode_idle_single_mode(data: IdleSingleModeExtractionData) -> IdleSingleModeOutput:
     return IdleSingleModeOutput(
-        key=_idle_single_mode_key(data.charaInfo.contents),
-        payload=_decode_idle_single_mode_data(data)
+            key=_idle_single_mode_key(data.charaInfo.contents),
+            payload=_decode_idle_single_mode_data(data)
     )

--- a/json_encoders.py
+++ b/json_encoders.py
@@ -1404,8 +1404,8 @@ def resolve_idle_single_mode(wdm: WorkDataManagerObject) -> Optional[IdleSingleM
 
 
 def _idle_single_mode_key(chara: SingleModeCharaObject, start_time: int) -> str:
-    dt = datetime.fromtimestamp(start_time, UTC).strftime('%Y%m%dT%H%M%SZ')
-    return f"{chara.fields.single_mode_chara_id}_{dt}_{chara.fields.card_id}"
+    dt = _timestamp_to_str(start_time)
+    return f"{chara.fields.single_mode_chara_id} {_safe_filename_component(dt)} {chara.fields.card_id}"
 
 
 def _decode_skill_tip_entry(s: SkillTipsObject) -> dict[str, Any]:
@@ -1656,7 +1656,7 @@ def _decode_chara_race_reward(rr: CharaRaceRewardObject) -> dict[str, Any]:
         "race_reward_bonus": [_decode_race_reward_data_entry(rd.contents) for rd in f.race_reward_bonus],
         "race_reward_plus_bonus": [_decode_race_reward_data_entry(rd.contents) for rd in f.race_reward_plus_bonus],
         "race_reward_bonus_win": [_decode_race_reward_data_entry(rd.contents) for rd in f.race_reward_bonus_win],
-        "race_reward_limit": None if not f.race_reward_limit.inner_ptr else [
+        "race_reward_limit": [] if not f.race_reward_limit.inner_ptr else [
             _decode_race_reward_limit_data_entry(ld.contents) for ld in f.race_reward_limit],
         "gained_fans": f.gained_fans,
         "campaign_id_array": [x.value for x in f.campaign_id_array],

--- a/json_encoders.py
+++ b/json_encoders.py
@@ -1385,6 +1385,7 @@ def resolve_idle_single_mode(wdm: WorkDataManagerObject) -> Optional[IdleSingleM
     c = idle_ptr.contents.fields
     checks = [
         (c.charaInfo, "charaInfo"),
+        (c.startTime, "startTime"),
         (c.endTime, "endTime"),
         (c.progressLogInfo, "progressLogInfo"),
     ]
@@ -1402,8 +1403,9 @@ def resolve_idle_single_mode(wdm: WorkDataManagerObject) -> Optional[IdleSingleM
     )
 
 
-def _idle_single_mode_key(chara: SingleModeCharaObject, start_time: Any) -> str:
-    return f"{start_time}-{chara.fields.card_id}"
+def _idle_single_mode_key(chara: SingleModeCharaObject, start_time: int) -> str:
+    dt = datetime.fromtimestamp(start_time, UTC).strftime('%Y%m%dT%H%M%SZ')
+    return f"{chara.fields.single_mode_chara_id}_{dt}_{chara.fields.card_id}"
 
 
 def _decode_skill_tip_entry(s: SkillTipsObject) -> dict[str, Any]:

--- a/json_encoders.py
+++ b/json_encoders.py
@@ -1362,8 +1362,8 @@ class IdleSingleModeOutput:
 @dataclass(frozen=True)
 class IdleSingleModeExtractionData:
     charaInfo: C_Ptr[SingleModeCharaObject]
-    startTime: C_Int[c_int64]
-    endTime: C_Int[c_int64]
+    startTime: int
+    endTime: int
     progressLogInfo: C_Ptr[ObscuredIdleSingleModeProgressLogInfoObject]
 
     def fingerprint(self) -> ExtractorFingerprint:

--- a/json_encoders.py
+++ b/json_encoders.py
@@ -8,8 +8,8 @@ from datetime import UTC, datetime, timedelta, timezone
 from typing import Any, Optional, Protocol
 
 from ctypes_utils import C_Int, C_Ptr
-from game_structs import (AcquiredSkillObject, BgSeason, CardDataDictionaryEntry, CardRarity, CharaGradeType, CharaRaceRewardObject,
-                          CourseDistanceType, DefeatType, EvaluationInfoObject, FactorDataObject,
+from game_structs import (AcquiredSkillObject, BgSeason, CardDataDictionaryEntry, CardRarity, CharaGradeType,
+                          CharaRaceRewardObject, CourseDistanceType, DefeatType, EvaluationInfoObject, FactorDataObject,
                           FactorDataUpgradeHistoryObject, FactorInfoObject, FavoriteDataDictionaryEntry,
                           FriendDataObject, GenericArrayPtr, GenericDictionary, GenericList, GroupOutingInfoObject,
                           GuestOutingInfoObject, HintLevelDictionaryEntry, HorseDataObject,
@@ -20,16 +20,16 @@ from game_structs import (AcquiredSkillObject, BgSeason, CardDataDictionaryEntry
                           ObscuredIdleSingleModeSupportCardGainInfoObject, ProperGrade, RaceCourseSetObject,
                           RaceDifficulty, RaceGroundCondition, RaceHistoryInfoObject, RaceHorseDataObject,
                           RaceHorseDataRaceResultObject, RaceInfoObject, RaceManagerStaticFields, RaceMotivation,
-                          RaceParameterObject, RaceRewardDataObject, RaceRewardLimitDataObject, RaceRunningType, RaceTime, RaceType, RaceWeather,
-                          ResultBoardConditionType, Rotation, RunningStyleEx, SingleModeCharaObject,
-                          SingleModeSkillUpgradeObject, SingleModeSupportCardObject, SingleRaceHistoryObject,
-                          SkillDataObject, SkillTipsObject, SuccessionCharaDataObject, SuccessionCharaPosition,
-                          SuccessionHistoryObject, SupportCardDataDictionaryEntry, TeamStadiumRaceCharaResultObject,
-                          TeamStadiumRaceResultObject, TeamStadiumResultBonusDataObject,
-                          TeamStadiumResultScoreDataObject, TrainedCharaDataDictionaryEntry, TrainedCharaDataObject,
-                          TrainedCharaSupportCardDataObject, TrainingLevelInfoObject,
-                          TrophyDataCharaIdListDictionaryEntry, TrophyDataDictionaryEntry, TurfVisionType,
-                          WorkDataManagerObject)
+                          RaceParameterObject, RaceRewardDataObject, RaceRewardLimitDataObject, RaceRunningType,
+                          RaceTime, RaceType, RaceWeather, ResultBoardConditionType, Rotation, RunningStyleEx,
+                          SingleModeCharaObject, SingleModeSkillUpgradeObject, SingleModeSupportCardObject,
+                          SingleRaceHistoryObject, SkillDataObject, SkillTipsObject, SuccessionCharaDataObject,
+                          SuccessionCharaPosition, SuccessionHistoryObject, SupportCardDataDictionaryEntry,
+                          TeamStadiumRaceCharaResultObject, TeamStadiumRaceResultObject,
+                          TeamStadiumResultBonusDataObject, TeamStadiumResultScoreDataObject,
+                          TrainedCharaDataDictionaryEntry, TrainedCharaDataObject, TrainedCharaSupportCardDataObject,
+                          TrainingLevelInfoObject, TrophyDataCharaIdListDictionaryEntry, TrophyDataDictionaryEntry,
+                          TurfVisionType, WorkDataManagerObject)
 from logger import logger
 
 JST = timezone(timedelta(hours=9), "JST")
@@ -1656,7 +1656,8 @@ def _decode_chara_race_reward(rr: CharaRaceRewardObject) -> dict[str, Any]:
         "race_reward_bonus": [_decode_race_reward_data_entry(rd.contents) for rd in f.race_reward_bonus],
         "race_reward_plus_bonus": [_decode_race_reward_data_entry(rd.contents) for rd in f.race_reward_plus_bonus],
         "race_reward_bonus_win": [_decode_race_reward_data_entry(rd.contents) for rd in f.race_reward_bonus_win],
-        "race_reward_limit": None if not f.race_reward_limit.inner_ptr else [_decode_race_reward_limit_data_entry(ld.contents) for ld in f.race_reward_limit],
+        "race_reward_limit": None if not f.race_reward_limit.inner_ptr else [
+            _decode_race_reward_limit_data_entry(ld.contents) for ld in f.race_reward_limit],
         "gained_fans": f.gained_fans,
         "campaign_id_array": [x.value for x in f.campaign_id_array],
     }

--- a/main.py
+++ b/main.py
@@ -25,12 +25,12 @@ from il2cpp_structs import (RuntimeIl2CppClass, RuntimeIl2CppGenericClass, Runti
                             RuntimeIl2CppMetadataRegistration, RuntimeIl2CppType)
 from il2cpp_utils import Il2CppResolutionManager
 from json_encoders import (CardDataExtractionData, ExtractorFingerprint, FingerprintableExtractionData,
-                           FriendDataExtractionData, RaceInfoReplayExtractionData, RaceReplayOutput,
+                           FriendDataExtractionData, IdleSingleModeExtractionData, IdleSingleModeOutput, RaceInfoReplayExtractionData, RaceReplayOutput,
                            SupportCardExtractionData, TeamStadiumReplayExtractionData, TrainedCharaExtractionData,
-                           TrophyDataExtractionData, decode_card_data_dictionary, decode_friend_data,
+                           TrophyDataExtractionData, decode_card_data_dictionary, decode_friend_data, decode_idle_single_mode,
                            decode_race_info_replay, decode_support_card_dictionary, decode_team_stadium_replay,
                            decode_trained_chara_dictionary, decode_trophy_data, resolve_card_data_extraction_data,
-                           resolve_friend_data_extraction_data, resolve_race_info_replay_extraction_data,
+                           resolve_friend_data_extraction_data, resolve_idle_single_mode, resolve_race_info_replay_extraction_data,
                            resolve_support_card_extraction_data, resolve_team_stadium_replay_extraction_data,
                            resolve_trained_chara_extraction_data, resolve_trophy_data_extraction_data)
 from logger import configure_logging, logger
@@ -422,6 +422,24 @@ def _extract_race_info_replay(data: RaceInfoReplayExtractionData) -> RaceReplayO
     return decode_race_info_replay(data)
 
 
+def _resolve_idle_single_mode(ctx: ExtractionContext) -> Optional[IdleSingleModeExtractionData]:
+    wdm = ctx.require_singleton(WORKDATAMANAGER_SINGLETON_SPEC)
+    return resolve_idle_single_mode(wdm)
+
+
+def _extract_idle_single_mode(data: IdleSingleModeExtractionData) -> IdleSingleModeOutput:
+    return decode_idle_single_mode(data)
+
+
+def _idle_single_mode_key(ism: IdleSingleModeOutput) -> str:
+    return ism.key
+
+
+def _write_idle_single_mode_json(output_folder: Path, key: str, ism: IdleSingleModeOutput) -> None:
+    output_path = output_folder / f"{key}.json"
+    _write_json_file(f"{output_folder.name}[{key}]", output_path, ism.payload)
+
+
 EXTRACTORS: tuple[Extractor[Any, Any, Any], ...] = (
     Extractor(
             name="support_cards",
@@ -468,6 +486,14 @@ EXTRACTORS: tuple[Extractor[Any, Any, Any], ...] = (
             extract=_extract_race_info_replay,
             key_fn=_replay_output_key,
             writer=_write_race_replay_json,
+    ),
+    Extractor(
+            name="idle_single_mode",
+            output_folder=Path("idle_single_mode"),
+            resolve=_resolve_idle_single_mode,
+            extract=_extract_idle_single_mode,
+            key_fn=_idle_single_mode_key,
+            writer=_write_idle_single_mode_json,
     ),
 )
 

--- a/main.py
+++ b/main.py
@@ -25,14 +25,16 @@ from il2cpp_structs import (RuntimeIl2CppClass, RuntimeIl2CppGenericClass, Runti
                             RuntimeIl2CppMetadataRegistration, RuntimeIl2CppType)
 from il2cpp_utils import Il2CppResolutionManager
 from json_encoders import (CardDataExtractionData, ExtractorFingerprint, FingerprintableExtractionData,
-                           FriendDataExtractionData, IdleSingleModeExtractionData, IdleSingleModeOutput, RaceInfoReplayExtractionData, RaceReplayOutput,
-                           SupportCardExtractionData, TeamStadiumReplayExtractionData, TrainedCharaExtractionData,
-                           TrophyDataExtractionData, decode_card_data_dictionary, decode_friend_data, decode_idle_single_mode,
+                           FriendDataExtractionData, IdleSingleModeExtractionData, IdleSingleModeOutput,
+                           RaceInfoReplayExtractionData, RaceReplayOutput, SupportCardExtractionData,
+                           TeamStadiumReplayExtractionData, TrainedCharaExtractionData, TrophyDataExtractionData,
+                           decode_card_data_dictionary, decode_friend_data, decode_idle_single_mode,
                            decode_race_info_replay, decode_support_card_dictionary, decode_team_stadium_replay,
                            decode_trained_chara_dictionary, decode_trophy_data, resolve_card_data_extraction_data,
-                           resolve_friend_data_extraction_data, resolve_idle_single_mode, resolve_race_info_replay_extraction_data,
-                           resolve_support_card_extraction_data, resolve_team_stadium_replay_extraction_data,
-                           resolve_trained_chara_extraction_data, resolve_trophy_data_extraction_data)
+                           resolve_friend_data_extraction_data, resolve_idle_single_mode,
+                           resolve_race_info_replay_extraction_data, resolve_support_card_extraction_data,
+                           resolve_team_stadium_replay_extraction_data, resolve_trained_chara_extraction_data,
+                           resolve_trophy_data_extraction_data)
 from logger import configure_logging, logger
 from memory import MemoryReader, TransientMemoryReadError
 from schema_validation import RuntimeValidatableIl2CppClassManager, TransientRuntimeValidationError


### PR DESCRIPTION
May or may not be "API-shaped." The script to check that frightens me. Output names match validation names.

We would expect final overall stats to be in `WorkDataManager.idleSingleModeData.workCharaData`, but in practice, that field is null in dumps. Instead, interested applications will have to use the starting `speed` &c. values in the `charaInfo` output field and roll up all gains in `progressLogInfo`.

Files are dumped to `./idle_single_mode/{career ID}_{start time}_{chara card ID}.json`, e.g. `./idle_single_mode/1818_20260726T150638Z_102001.json`.
Confirmed idle single mode dump works in daemon mode.